### PR TITLE
Add a page for viewing all apps, and a page for viewing just one app'…

### DIFF
--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -5,3 +5,15 @@
  */
 
 // You can delete this file if you're not using it
+
+// Ensures that client-side routing works on the desired pages
+exports.onCreatePage = async ({ page, actions }) => {
+  const { createPage } = actions
+  if (page.path.match(/^\/apps/)) {
+    // page.matchPath is a special key that's used for matching pages
+    // with corresponding routes only on the client.
+    page.matchPath = "/apps/*"
+    // Update the page.
+    createPage(page)
+  }
+}

--- a/frontend/src/client-pages/AnAppPage.js
+++ b/frontend/src/client-pages/AnAppPage.js
@@ -1,0 +1,47 @@
+import React from "react"
+import AppCarousel from "../components/app-carousel"
+import "bootstrap/dist/css/bootstrap.min.css"
+import { Jumbotron, Container } from "reactstrap"
+
+const AnAppPage = props => {
+  const { appId } = props
+  const [app, setApp] = React.useState(null)
+
+  React.useEffect(() => {
+    ;(async () => {
+      const app = await fetchApp(appId)
+      setApp(app)
+    })()
+  }, [])
+
+  if (app) {
+    const { name, description } = app
+    return (
+      <div className={"AnAppPage-container"}>
+        <AppCarousel apps={[app]}></AppCarousel>
+        <Jumbotron fluid>
+          <Container fluid>
+            <h1 className={"display-3"}>{name}</h1>
+            <p className={"lead"}>{description}</p>
+          </Container>
+        </Jumbotron>
+      </div>
+    )
+  }
+
+  return null
+}
+
+export default AnAppPage
+
+// TODO: This needs to fetch data from the server. To minimize client processing, we should query for the specific app id.
+const fetchApp = async appId => {
+  return {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  }
+}

--- a/frontend/src/client-pages/AnAppPage.js
+++ b/frontend/src/client-pages/AnAppPage.js
@@ -2,6 +2,7 @@ import React from "react"
 import AppCarousel from "../components/app-carousel"
 import "bootstrap/dist/css/bootstrap.min.css"
 import { Jumbotron, Container } from "reactstrap"
+import { mapApp } from "../helpers/mappers"
 
 const AnAppPage = props => {
   const { appId } = props
@@ -36,12 +37,14 @@ export default AnAppPage
 
 // TODO: This needs to fetch data from the server. To minimize client processing, we should query for the specific app id.
 const fetchApp = async appId => {
-  return {
+  const appData = {
     name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
     description: "The world's leading social media platform",
-    url: "/apps/1",
+    image: undefined,
+    github_url: "http://www.github.com",
+    app_url: "http://www.app.com",
+    id: 1,
   }
+
+  return mapApp(appData)
 }

--- a/frontend/src/components/app-carousel.js
+++ b/frontend/src/components/app-carousel.js
@@ -84,3 +84,5 @@ export const AppCarousel = props => {
     </div>
   )
 }
+
+export default AppCarousel

--- a/frontend/src/helpers/mappers.js
+++ b/frontend/src/helpers/mappers.js
@@ -1,0 +1,21 @@
+/**
+ * This file exports the functions that map the data retrieved from the backend to the
+ * data used in the views.
+ */
+
+export const mapApp = appData => {
+  const { name, description, img, app_url, github_url, id } = appData
+
+  return {
+    name: name,
+    description: description,
+    image: img,
+    appUrl: app_url,
+    githubUrl: github_url,
+
+    url: `/apps/${id}`,
+    imageUrl: img
+      ? ""
+      : "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+  }
+}

--- a/frontend/src/pages/apps.js
+++ b/frontend/src/pages/apps.js
@@ -7,6 +7,7 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 import AnAppPage from "../client-pages/AnAppPage"
 import { AppGrid } from "../components/app-grid"
+import { mapApp } from "../helpers/mappers"
 
 const AppPage = () => {
   return (
@@ -36,64 +37,40 @@ const AllApps = () => {
 }
 
 const fetchApps = async () => {
-  return apps
+  return apps.map(app => mapApp(app))
 }
 
 const apps = [
   {
     name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
     description: "The world's leading social media platform",
-    url: "/apps/1",
+    image: undefined,
+    github_url: "http://www.github.com",
+    app_url: "http://www.app.com",
+    id: 1,
   },
   {
     name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
     description: "The world's leading social media platform",
-    url: "/apps/1",
+    image: undefined,
+    github_url: "http://www.github.com",
+    app_url: "http://www.app.com",
+    id: 1,
   },
   {
     name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
     description: "The world's leading social media platform",
-    url: "/apps/1",
+    image: undefined,
+    github_url: "http://www.github.com",
+    app_url: "http://www.app.com",
+    id: 1,
   },
   {
     name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
     description: "The world's leading social media platform",
-    url: "/apps/1",
-  },
-  {
-    name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
     image: undefined,
-    description: "The world's leading social media platform",
-    url: "/apps/1",
-  },
-  {
-    name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
-    description: "The world's leading social media platform",
-    url: "/apps/1",
-  },
-  {
-    name: "Facebook",
-    imageUrl:
-      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
-    image: undefined,
-    description: "The world's leading social media platform",
-    url: "/apps/1",
+    github_url: "http://www.github.com",
+    app_url: "http://www.app.com",
+    id: 1,
   },
 ]

--- a/frontend/src/pages/apps.js
+++ b/frontend/src/pages/apps.js
@@ -1,0 +1,99 @@
+import React from "react"
+import { Link } from "gatsby"
+
+import { Router } from "@reach/router"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+import AnAppPage from "../client-pages/AnAppPage"
+import { AppGrid } from "../components/app-grid"
+
+const AppPage = () => {
+  return (
+    <Layout>
+      <SEO title="Apps" />
+      <Router basepath={"/apps"}>
+        <AllApps path={"/"}></AllApps>
+        <AnAppPage path={"/:appId"}></AnAppPage>
+      </Router>
+    </Layout>
+  )
+}
+
+export default AppPage
+
+const AllApps = () => {
+  const [apps, setApps] = React.useState([])
+
+  React.useEffect(() => {
+    ;(async () => {
+      const apps = await fetchApps()
+      setApps(apps)
+    })()
+  }, [])
+
+  return <AppGrid apps={apps}></AppGrid>
+}
+
+const fetchApps = async () => {
+  return apps
+}
+
+const apps = [
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+  {
+    name: "Facebook",
+    imageUrl:
+      "https://brandthunder.com/wp/wp-content/uploads/2012/07/Facebook-skins-post.png",
+    image: undefined,
+    description: "The world's leading social media platform",
+    url: "/apps/1",
+  },
+]


### PR DESCRIPTION
I've added routes for viewing all apps and for viewing a single app's description: respectively, `/apps` and `/apps/:app_id`. Clicking any of the apps on `/apps` should take you to the corresponding `/apps/:app_id` page.