### PR TITLE
Update skills pages to pull developers filtered by hard-coded skill id

### DIFF
--- a/frontend/src/pages/devs/rails.js
+++ b/frontend/src/pages/devs/rails.js
@@ -3,11 +3,30 @@ import React from "react"
 import Layout from "../../components/Layout/Layout"
 import SEO from "../../components/Seo/Seo"
 
-const RailsPage = () => (
-  <Layout>
-    <SEO title="rails" />
-    <h1>rails</h1>
-  </Layout>
-)
+import UserGrid from "../../components/UserGrid/UserGrid"
+import getAllUsers from "../../shared/fetchActions/getAllUsers"
+import * as forFrontend from "../../shared/convertForFrontend"
+
+const RailsPage = () => {
+  const [users, setUsers] = React.useState([])
+
+  React.useEffect(() => {
+    ;(async () => {
+      const usersData = await getAllUsers({
+        skill: 1,
+      })
+      const users = usersData.map(forFrontend.convertUser)
+      setUsers(users)
+    })()
+  }, [])
+
+  return (
+    <Layout>
+      <SEO title="rails" />
+      <h1>rails</h1>
+      <UserGrid users={users} />
+    </Layout>
+  )
+}
 
 export default RailsPage

--- a/frontend/src/pages/devs/react.js
+++ b/frontend/src/pages/devs/react.js
@@ -3,11 +3,30 @@ import React from "react"
 import Layout from "../../components/Layout/Layout"
 import SEO from "../../components/Seo/Seo"
 
-const ReactPage = () => (
-  <Layout>
-    <SEO title="react" />
-    <h1>react</h1>
-  </Layout>
-)
+import UserGrid from "../../components/UserGrid/UserGrid"
+import getAllUsers from "../../shared/fetchActions/getAllUsers"
+import * as forFrontend from "../../shared/convertForFrontend"
+
+const ReactPage = () => {
+  const [users, setUsers] = React.useState([])
+
+  React.useEffect(() => {
+    ;(async () => {
+      const usersData = await getAllUsers({
+        skill: 3,
+      })
+      const users = usersData.map(forFrontend.convertUser)
+      setUsers(users)
+    })()
+  }, [])
+
+  return (
+    <Layout>
+      <SEO title="react" />
+      <h1>react</h1>
+      <UserGrid users={users} />
+    </Layout>
+  )
+}
 
 export default ReactPage

--- a/frontend/src/pages/devs/vue.js
+++ b/frontend/src/pages/devs/vue.js
@@ -3,11 +3,30 @@ import React from "react"
 import Layout from "../../components/Layout/Layout"
 import SEO from "../../components/Seo/Seo"
 
-const VuePage = () => (
-  <Layout>
-    <SEO title="vue" />
-    <h1>vue</h1>
-  </Layout>
-)
+import UserGrid from "../../components/UserGrid/UserGrid"
+import getAllUsers from "../../shared/fetchActions/getAllUsers"
+import * as forFrontend from "../../shared/convertForFrontend"
+
+const VuePage = () => {
+  const [users, setUsers] = React.useState([])
+
+  React.useEffect(() => {
+    ;(async () => {
+      const usersData = await getAllUsers({
+        skill: 2,
+      })
+      const users = usersData.map(forFrontend.convertUser)
+      setUsers(users)
+    })()
+  }, [])
+
+  return (
+    <Layout>
+      <SEO title="vue" />
+      <h1>vue</h1>
+      <UserGrid users={users} />
+    </Layout>
+  )
+}
 
 export default VuePage

--- a/frontend/src/shared/fetchActions/getAllUsers.js
+++ b/frontend/src/shared/fetchActions/getAllUsers.js
@@ -1,8 +1,15 @@
 import fetchJsonAndParse from "./fetchJsonAndParse"
 import * as Url from "../urls"
 
-const getAllUsers = async () => {
-  const request = new Request(Url.USERS, {
+const getAllUsers = async queryParams => {
+  let queryString = queryParams
+    ? Object.entries(queryParams).reduce((acc, [key, value]) => {
+        return acc + `${key}=${value}&`
+      }, "")
+    : ""
+
+  const url = `${Url.USERS}?${queryString}`
+  const request = new Request(url, {
     method: "GET",
     credentials: "include",
   })


### PR DESCRIPTION
This PR updates the `rails`, `vue`, and `react` pages to pull users based on whether they have the skill in the backend. This is run against the `master` branch of the backend (reset the database and re-seed so that the Rails, Vue, and React skills exist in the backend`.

Technical debt: the `id` of the skills is hard-coded. With the time remaining, I don't think it is worth it to fix this.

![skills](https://user-images.githubusercontent.com/62522740/83921196-b380fd80-a732-11ea-9a35-91fe56946a8b.PNG)
